### PR TITLE
HACC submodule updates

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "HACC/HACC-B24"]
+	path = HACC/HACC-B24
+	url = https://git.cels.anl.gov/hacc/HACC-B24.git

--- a/HACC/README.md
+++ b/HACC/README.md
@@ -4,6 +4,25 @@
 
 ## Code Access
 
+The source code for the ALCF4 HACC benchmark is provided as a submodule of the alcf4_benchmarks project. The easiest way to obtain the code is to recursively clone submodules when cloning the main project:
+```
+git clone --recurse-submodules https://github.com/argonne-lcf/alcf4_benchmarks.git
+```
+
+The submodules can also be obtained after the initial clone of the main project via the following:
+```
+git clone https://github.com/argonne-lcf/alcf4_benchmarks.git
+cd alcf4_benchmarks
+git submodule update --init
+```
+
+We also provide a convenience script that will perform the same action:
+```
+git clone https://github.com/argonne-lcf/alcf4_benchmarks.git
+cd alcf4_benchmarks/HACC
+./git_submodule_init.sh
+```
+
 ### HACC configuration used in Aurora benchmark
 
 ### FOM

--- a/HACC/README.md
+++ b/HACC/README.md
@@ -16,12 +16,14 @@ cd alcf4_benchmarks
 git submodule update --init
 ```
 
-We also provide a convenience script that will perform the same action:
+A convenience script that will perform the same action is also provided:
 ```
 git clone https://github.com/argonne-lcf/alcf4_benchmarks.git
 cd alcf4_benchmarks/HACC
 ./git_submodule_init.sh
 ```
+
+The ALCF4 HACC benchmark source code can also be obtained directly from the publicly-accessible project on the Argonne CELS gitlab: https://git.cels.anl.gov/hacc/HACC-B24
 
 ### HACC configuration used in Aurora benchmark
 

--- a/HACC/git_submodule_init.sh
+++ b/HACC/git_submodule_init.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+git submodule update --init


### PR DESCRIPTION
Adding mechanism and documentation for downloading HACC ALCF4 benchmark source code as submodule of alcf4_benchmarks project.